### PR TITLE
注销bug修改

### DIFF
--- a/web/first-app/src/app/app-routing.module.ts
+++ b/web/first-app/src/app/app-routing.module.ts
@@ -1,10 +1,20 @@
 import {NgModule} from '@angular/core';
 import {Routes, RouterModule} from '@angular/router';
 import {WelcomeComponent} from './welcome/welcome.component';
+import {LoginComponent} from './login/login.component';
 
 const routes: Routes = [
   {
     path: '',
+    redirectTo: 'login',
+    pathMatch: 'full'
+  },
+  {
+    path: 'login',
+    component: LoginComponent,
+  },
+  {
+    path: './login/',
     component: WelcomeComponent,
   },
   {


### PR DESCRIPTION
解决了不同role登录可以切换不同导航，但登录后仍存在login界面
个人认为：若在登录后重置路由，即去除url中的login即可。（正在找解决办法）
![image](https://user-images.githubusercontent.com/86513476/176690424-7c136a4a-7de6-423f-8e49-185e43ee5e81.png)
![image](https://user-images.githubusercontent.com/86513476/176690519-0359027d-384f-4b88-8621-0d405be45252.png)
