### PR TITLE
teacher -> schedule -> index debug

### DIFF
--- a/web/first-app/src/app/entity/program.ts
+++ b/web/first-app/src/app/entity/program.ts
@@ -1,10 +1,8 @@
 import {BaseEntity} from './base-entity';
-import {Teacher} from './teacher';
-import {Term} from './term';
 import {Course} from './course';
 
 export interface Schedule extends BaseEntity {
-  teacher: Teacher;
-  term: Term;
+  name: string;
   course: Course;
+  lesson: number;
 }

--- a/web/first-app/src/app/service/program.service.ts
+++ b/web/first-app/src/app/service/program.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {Observable} from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProgramService {
+
+  constructor(private httpClient: HttpClient) { }
+
+  add(data: {name: string, course_id: number, lesson: number}): Observable<any> {
+    return this.httpClient.post('/program/add', data);
+  }
+
+}

--- a/web/first-app/src/app/service/schedule.service.ts
+++ b/web/first-app/src/app/service/schedule.service.ts
@@ -4,7 +4,10 @@ import {Observable} from 'rxjs';
 import {Schedule} from '../entity/schedule';
 import {Page} from '../entity/page';
 import {map} from 'rxjs/operators';
-import {ScheduleKlass} from '../entity/schedule_klass';
+import {UserService} from './user.service';
+import {Course} from '../entity/course';
+import {Clazz} from '../entity/clazz';
+import {Term} from '../entity/term';
 
 @Injectable({
   providedIn: 'root'
@@ -12,39 +15,49 @@ import {ScheduleKlass} from '../entity/schedule_klass';
 export class ScheduleService {
 
   constructor(
-    private httpClient: HttpClient
+    private httpClient: HttpClient,
+    private userService: UserService
   ) {
   }
 
-  page(page: number, size: number): Observable<Page<ScheduleKlass>> {
+  editIndex(id: number): Observable<any> {
+    const httpParams = new HttpParams()
+      .append('id', id.toString());
+    return this.httpClient.get<any>('/schedule/editIndex', {params: httpParams});
+  }
+
+  page(page: number, size: number): Observable<Page<{schedule: Schedule, clazzes: Clazz[]}>> {
     const httpParams = new HttpParams()
       .append('page', page.toString())
       .append('size', size.toString());
-    return this.httpClient.get<{length: number, content: {
-        schedule_id: number,
-        clazz_name: string,
-        course_name: string,
-        term_name: string
-      }[]}>('/schedule/page', {params: httpParams})
+    return this.httpClient.get<{
+      length: number,
+      content: {
+        schedules: {id: number}[],
+        clazzes: {clazzes: Clazz[]}[],
+        teachers: {id: number, name: string}[],
+        terms: {id: number, name: string}[],
+        courses: {id: number, name: string}[],
+      }}>('/schedule/page', {params: httpParams})
       .pipe(map(data => {
-          const content: ScheduleKlass[] = [];
-          for (const scheduleKlass  of data.content) {
+          const content: {schedule: Schedule, clazzes: Clazz[]}[] = [];
+          const arrayGroup = data.content;
+          console.log('service schedule', data);
+          for (let i = 0; i < arrayGroup.schedules.length; i++) {
             content.push({
               schedule: {
-                id: scheduleKlass.schedule_id,
+                id: arrayGroup.schedules[i].id,
                 course: {
-                  name: scheduleKlass.course_name
-                },
+                  name: arrayGroup.courses[i].name
+                } as Course,
                 term: {
-                  name: scheduleKlass.term_name
-                }
-              },
-              clazz: {
-                name: scheduleKlass.clazz_name
-              }
-            } as ScheduleKlass);
+                  name: arrayGroup.terms[i].name
+                } as Term
+              } as Schedule,
+              clazzes: arrayGroup.clazzes[i].clazzes as Clazz[]
+            });
           }
-          return new Page<ScheduleKlass>({
+          return new Page<{schedule: Schedule, clazzes: Clazz[]}>({
             content,
             number: page,
             size,

--- a/web/first-app/src/app/service/schedule.service.ts
+++ b/web/first-app/src/app/service/schedule.service.ts
@@ -52,7 +52,10 @@ export class ScheduleService {
                 } as Course,
                 term: {
                   name: arrayGroup.terms[i].name
-                } as Term
+                } as Term,
+                teacher: {
+                  name: arrayGroup.teachers[i].name
+                }
               } as Schedule,
               clazzes: arrayGroup.clazzes[i].clazzes as Clazz[]
             });

--- a/web/first-app/src/app/teacher/schedule/schedule-edit/program-add/program-add.component.html
+++ b/web/first-app/src/app/teacher/schedule/schedule-edit/program-add/program-add.component.html
@@ -1,21 +1,23 @@
-<div>
-  <input type="hidden" name="schedule_id" value="{:$Schedule->id}">
-  <div class="form-group row">
-    <label for="name" class="col-sm-2 col-form-label"><code>*</code>项目名称</label>
-    <div class="col-sm-4">
-      <input type="text" class="form-control" id="name" name="name" required>
+<form [formGroup]="formGroup">
+  <div>
+    <input type="hidden" name="schedule_id" value="{:$Schedule->id}">
+    <div class="form-group row">
+      <label for="name" class="col-sm-2 col-form-label"><code>*</code>项目名称</label>
+      <div class="col-sm-4">
+        <input type="text" class="form-control" id="name" formControlName="name" required>
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <label for="lesson" class="col-sm-2 col-form-label"><code>*</code>项目课时</label>
-    <div class="col-sm-4">
-      <input type="text" class="form-control" id="lesson" name="lesson" required>
+    <div class="form-group row">
+      <label for="lesson" class="col-sm-2 col-form-label"><code>*</code>项目课时</label>
+      <div class="col-sm-4">
+        <input type="text" class="form-control" id="lesson" formControlName="lesson" required>
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <div class="col-sm-10">
-      <button type="submit" class="btn btn-primary">保存</button>
-      <a routerLink="/teacher/schedule/edit" class="btn btn-primary"><i class="glyphicon"></i>&nbsp;返回</a>
+    <div class="form-group row">
+      <div class="col-sm-10">
+        <button type="submit" class="btn btn-primary" (click)="onSubmit()" [disabled]="formGroup.invalid">保存</button>
+        <a routerLink="/teacher/schedule/edit" class="btn btn-primary"><i class="glyphicon"></i>&nbsp;返回</a>
+      </div>
     </div>
-  </div>
 </div>
+</form>

--- a/web/first-app/src/app/teacher/schedule/schedule-edit/program-add/program-add.component.ts
+++ b/web/first-app/src/app/teacher/schedule/schedule-edit/program-add/program-add.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {ProgramService} from '../../../../service/program.service';
+import {ScheduleService} from '../../../../service/schedule.service';
 
 @Component({
   selector: 'app-program-add',
@@ -6,10 +9,21 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./program-add.component.css']
 })
 export class ProgramAddComponent implements OnInit {
+  formGroup = new FormGroup({
+    name: new FormControl('', Validators.required),
+    lesson: new FormControl(null, Validators.required),
+  });
 
-  constructor() { }
+  constructor(private programService: ProgramService) { }
 
   ngOnInit(): void {
+  }
+  onSubmit(): void {
+    this.programService.add({
+      name: this.formGroup.get('name')?.value,
+      lesson: this.formGroup.get('lesson')?.value,
+      course_id: 1,
+    });
   }
 
 }

--- a/web/first-app/src/app/teacher/schedule/schedule-edit/schedule-edit.component.html
+++ b/web/first-app/src/app/teacher/schedule/schedule-edit/schedule-edit.component.html
@@ -1,3 +1,6 @@
+<pre>
+  {{data | json}}
+</pre>
 <div class="row">
   <div class="col col-md-8">
     <div class="col-sm-12">

--- a/web/first-app/src/app/teacher/schedule/schedule-edit/schedule-edit.component.ts
+++ b/web/first-app/src/app/teacher/schedule/schedule-edit/schedule-edit.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import {ScheduleService} from '../../../service/schedule.service';
+import {ActivatedRoute} from '@angular/router';
 
 @Component({
   selector: 'app-schedule-edit',
@@ -7,9 +9,19 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ScheduleEditComponent implements OnInit {
 
-  constructor() { }
-
+  constructor(private scheduleService: ScheduleService,
+              private route: ActivatedRoute) { }
+  id: number | undefined;
+  data = {};
   ngOnInit(): void {
+    this.id = +this.route.snapshot.params.schedule_id;
+    this.scheduleService.editIndex(this.id)
+      .subscribe(data => {
+        this.data = data;
+        console.log('scheduleEditIndex success', data);
+      }, error => {
+        console.log('scheduleEditIndex error', error);
+      });
   }
 
 }

--- a/web/first-app/src/app/teacher/schedule/schedule-index/schedule-index.component.html
+++ b/web/first-app/src/app/teacher/schedule/schedule-index/schedule-index.component.html
@@ -25,14 +25,18 @@
   </tr>
   </thead>
   <tbody>
-  <tr *ngFor="let scheduleKlass of pageData.content index as i">
+  <tr *ngFor="let unit of pageData.content index as i">
     <td>{{ i + 1 }}</td>
-    <td>{{ scheduleKlass.schedule.course.name }}</td>
-    <td>{{ scheduleKlass.schedule.term.name }}</td>
-    <td>{{ scheduleKlass.clazz.name }}</td>
+    <td>{{ unit.schedule.course.name }}</td>
+    <td>{{ unit.schedule.term.name }}</td>
     <td>
-      <a class="btn btn-sm btn-primary" routerLink="edit"><i class="fas fa-pen"></i>编辑</a>&nbsp;&nbsp;
-      <a class="btn btn-sm btn-danger" (click)="onDelete(scheduleKlass.schedule.id)"><i class="far fa-trash-alt"></i>删除</a>
+      <ng-template ngFor let-item [ngForOf]="unit.clazzes" let-i="index">
+        {{ item.name }}
+      </ng-template>
+    </td>
+    <td>
+      <a class="btn btn-sm btn-primary" [routerLink]="'edit/' + unit.schedule.id"><i class="fas fa-pen"></i>编辑</a>&nbsp;&nbsp;
+      <a class="btn btn-sm btn-danger" (click)="onDelete(unit.schedule.id)"><i class="far fa-trash-alt"></i>删除</a>
     </td>
   </tr>
   </tbody>

--- a/web/first-app/src/app/teacher/schedule/schedule-index/schedule-index.component.ts
+++ b/web/first-app/src/app/teacher/schedule/schedule-index/schedule-index.component.ts
@@ -5,6 +5,7 @@ import {HttpClient, HttpParams} from '@angular/common/http';
 import {ScheduleService} from '../../../service/schedule.service';
 import {Confirm, Notify} from 'notiflix';
 import {ScheduleKlass} from '../../../entity/schedule_klass';
+import {Clazz} from '../../../entity/clazz';
 
 @Component({
   selector: 'app-schedule-index',
@@ -16,7 +17,7 @@ export class ScheduleIndexComponent implements OnInit {
   page = 0;
   size = 10;
 
-  pageData = new Page<ScheduleKlass>({
+  pageData = new Page<{schedule: Schedule, clazzes: Clazz[]}>({
     content: [],
     number: this.page,
     size: this.size,

--- a/web/first-app/src/app/teacher/schedule/schedule-routing.module.ts
+++ b/web/first-app/src/app/teacher/schedule/schedule-routing.module.ts
@@ -16,27 +16,27 @@ const routes: Routes = [
     component: ScheduleIndexComponent
   },
   {
-    path: 'edit',
+    path: 'edit/:schedule_id',
     component: ScheduleEditComponent
   },
   {
-    path: 'edit/programAdd',
+    path: 'edit/:schedule_id/programAdd',
     component: ProgramAddComponent
   },
   {
-    path: 'edit/clazzAdd',
+    path: 'edit/:schedule_id/clazzAdd',
     component: ClazzAddComponent
   },
   {
-    path: 'edit/timeAdd',
+    path: 'edit/:schedule_id/timeAdd',
     component: TimeAddComponent
   },
   {
-    path: 'edit/programEdit',
+    path: 'edit/:schedule_id/programEdit',
     component: ProgramEditComponent
   },
   {
-    path: 'edit/nameEdit',
+    path: 'edit/:schedule_id/nameEdit',
     component: NameEditComponent
   },
   {

--- a/web/first-app/src/app/teacher/schedule/schedule.module.ts
+++ b/web/first-app/src/app/teacher/schedule/schedule.module.ts
@@ -8,6 +8,7 @@ import { TimeAddComponent } from './schedule-edit/time-add/time-add.component';
 import { ProgramEditComponent } from './schedule-edit/program-edit/program-edit.component';
 import { NameEditComponent } from './schedule-edit/name-edit/name-edit.component';
 import { ScheduleAddComponent } from './schedule-add/schedule-add.component';
+import {ReactiveFormsModule} from '@angular/forms';
 
 
 
@@ -23,7 +24,8 @@ import { ScheduleAddComponent } from './schedule-add/schedule-add.component';
   ],
   imports: [
     CommonModule,
-    ScheduleRoutingModule
+    ScheduleRoutingModule,
+    ReactiveFormsModule
   ]
 })
 export class ScheduleModule { }


### PR DESCRIPTION
#343 
debug:
1、 显示出的排课信息根据当前登录用户获取
2、index界面的显示有问题:
            在某个排课对应多个班级的情况下会分三条显示，实际上应该是一条数据，班级处应该是3个班级
            问题2的解决： 
            ①修改了pageData类型为 Page<{schedule: Schedule, clazzes: Clazz[]}>
            ②后台返回类型：
            {
                length: number,
                content: {
                  schedules: {id: number}[],
                  clazzes: {clazzes: Clazz[]}[],
                  teachers: {id: number, name: string}[],
                  terms: {id: number, name: string}[],
                  courses: {id: number, name: string}[],
             }
            ③通过pipe(map)管道将类型修改为：
            {  
               schedule: {
                  id,
                  Course,
                  Teacher,
                  Term
                }
                 clazzes: Clazz[]
             }
