### PR TITLE
新增排课-》时间选择小单元、 course查询功能的一个debug

### DIFF
--- a/api/application/api/controller/CourseController.php
+++ b/api/application/api/controller/CourseController.php
@@ -16,6 +16,7 @@ class CourseController extends Controller
     */
     public function page() {
         $params = Request()->param();
+
         $query = Course::order(['id desc'])
                     ->where('name', 'like', '%' . $params['searchName'] . '%')
                     ->where('lesson', 'like', '%' . $params['searchLesson'] . '%');

--- a/api/application/api/controller/ScheduleController.php
+++ b/api/application/api/controller/ScheduleController.php
@@ -115,7 +115,16 @@ class ScheduleController extends Controller {
     }
 
     public function getSelectedClazzes() {
-            return json_encode(Klass::All());
+        return json_encode(Klass::All());
+    }
+
+    public function getSelectedRooms() {
+        return json_encode(Room::All());
+    }
+
+    public function getCurrentTerm() {
+        $currentTerm = Term::getCurrentTerm();
+        return json_encode($currentTerm);
     }
 
 }

--- a/web/first-app/src/app/service/course.service.ts
+++ b/web/first-app/src/app/service/course.service.ts
@@ -17,6 +17,11 @@ export class CourseService {
   */
   page({page = 0, size = 20}: { size?: number; page?: number }, course: { name?: string; lesson?: string} ): Observable<Page<Course>> {
     let courses = [] as Course[];
+
+    if (course.lesson === null) {
+      course.lesson = '';
+    }
+
     console.log('444');
     console.log(course);
     console.log('555');

--- a/web/first-app/src/app/service/schedule.service.ts
+++ b/web/first-app/src/app/service/schedule.service.ts
@@ -124,4 +124,14 @@ export class ScheduleService {
     console.log('获取可选择课程');
     return this.httpClient.get<[]>('/schedule/getSelectedClazzes');
   }
+
+  getSelectedRooms(): Observable<[]> {
+    console.log('获取可选择教室');
+    return this.httpClient.get<[]>('/schedule/getSelectedRooms');
+  }
+
+  getCurrentTerm(): Observable<Term> {
+    console.log('获取当前学期');
+    return this.httpClient.get<Term>('/schedule/getCurrentTerm');
+  }
 }

--- a/web/first-app/src/app/teacher/schedule/schedule-add/schedule-add.component.html
+++ b/web/first-app/src/app/teacher/schedule/schedule-add/schedule-add.component.html
@@ -73,12 +73,12 @@
                         <div class="row">
                           <div class="col-sm-6">
                             <div class="row" *ngFor="let week of weeks">
-                              <input type="checkBox">&nbsp;<label>第{{week}}周</label>
+                              &nbsp;&nbsp;<input type="checkBox">&nbsp;<label>第{{week}}周</label>
                             </div>
                           </div>
                           <div class="col-sm-6">
                             <div class="row" *ngFor="let room of rooms">
-                              <input type="checkBox">&nbsp;<label>教室{{room}}</label>
+                              <input type="checkBox">&nbsp;<label>{{room.name}}</label>
                             </div>
                           </div>
                         </div>

--- a/web/first-app/src/app/teacher/schedule/schedule-add/schedule-add.component.ts
+++ b/web/first-app/src/app/teacher/schedule/schedule-add/schedule-add.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import {ScheduleService} from '../../../service/schedule.service';
 import {Course} from '../../../entity/course';
 import {Clazz} from '../../../entity/clazz';
+import {Room} from '../../../entity/room';
 
 
 @Component({
@@ -11,10 +12,12 @@ import {Clazz} from '../../../entity/clazz';
 })
 export class ScheduleAddComponent implements OnInit {
 
+  constructor(private scheduleService: ScheduleService) { }
+
   lessons = [1, 2, 3, 4, 5];
   days = ['一', '二', '三', '四', '五', '六', '日'];
-  weeks = [1, 2, 3, 4, 5, 6, 7, 8];
-  rooms = [1, 2, 3, 4, 5];
+  weeks = [];
+  rooms = [] as Room[];
   h5_day: string | undefined;
   h5_lesson: number | undefined;
 
@@ -23,11 +26,11 @@ export class ScheduleAddComponent implements OnInit {
   isShowSelectClazz = false;
   isShowSelectTime = false;
 
-  constructor(private scheduleService: ScheduleService) { }
-
   ngOnInit(): void {
     this.getSelectedCourses();
     this.getSelectedClazzes();
+    this.getSelectedRooms();
+    this.getSelectedWeeks();
   }
 
 
@@ -54,6 +57,40 @@ export class ScheduleAddComponent implements OnInit {
         this.selectedClazzes = data;
       }, error => {
         console.log('获取可可选择的班级失败', error);
+      });
+  }
+
+  getSelectedRooms(): void {
+    this.scheduleService.getSelectedRooms()
+      .subscribe(data => {
+        console.log('获取可选择教室成功', data);
+        this.rooms = data;
+      }, error => {
+        console.log('获取可可选择的教室失败', error);
+      });
+  }
+
+  getSelectedWeeks(): void {
+    this.scheduleService.getCurrentTerm()
+      .subscribe(term => {
+        console.log('获取可选择周数成功', term);
+        const dateStart = new Date((+term.start_time) * 1000);
+        const dateEnd = new Date((+term.end_time) * 1000);
+
+        console.log(dateStart);
+        console.log(dateEnd);
+
+        const difValue = (dateEnd - dateStart) / (1000 * 60 * 60 * 24);
+
+        console.log(difValue);
+        for (let i = 0; i < Math.ceil(difValue / 7); i++) {
+          this.weeks.push(i + 1);
+        }
+
+        console.log(this.weeks);
+
+      }, error => {
+        console.log('获取可可选择的周数失败', error);
       });
   }
 


### PR DESCRIPTION
#368 周数由后台获取当前学期的起始时间计算得来，教室数从后台获取all
<img width="369" alt="1657724978510_9F305C90-57F9-4cad-94E7-3FEEDE938823" src="https://user-images.githubusercontent.com/100888986/178768542-2f9379a7-5ae7-4a5f-8d8a-d29d7f1399c4.png">
查询功能debug: 若初始lesson为null，则将其赋值为‘ ’（空字符）；