### PR TITLE
学生管理模块bug修改

### DIFF
--- a/api/application/api/controller/StudentController.php
+++ b/api/application/api/controller/StudentController.php
@@ -85,6 +85,7 @@ class StudentController extends Controller
         $user = Db::table('yunzhi_user')->alias('user')
         ->join('yunzhi_student student',  'user.id = student.user_id')
         ->join('yunzhi_klass klass', 'student.klass_id = klass.id')
+        ->field('student.id, student.user_id, user.number, user.sex, user.name, student.sno,  klass.id as klass_id')
         ->where("user.id=$id")->find();
         return json_encode($user);
     }


### PR DESCRIPTION
学期管理-》学期激活bug：
学期中存在已激活学期，激活按钮正常
学期列表中未有激活学期，点击激活按钮，报错如下
![image](https://user-images.githubusercontent.com/86513476/179350980-93bfce62-4ea5-4953-87b0-de645be75322.png)
